### PR TITLE
Add Service Account credentials via an environment variable

### DIFF
--- a/pygdrive/gdrive.py
+++ b/pygdrive/gdrive.py
@@ -174,9 +174,9 @@ class Gdrive:
         item = results.get("files", [])
         return item
         
-    def get_file_in_folder_by_type(self, folder_id, mimetype):
+    def get_files_in_folder_by_type(self, folder_id, mimetype):
         """
-        Searching for all folders sorted by createdTime inside folder.
+        Searching for all files of mimetype sorted by createdTime inside folder.
         :str folder_id: : Id of the folder.
         :return: [{"id":"str", "name":"str"}]
         """

--- a/pygdrive/gdrive.py
+++ b/pygdrive/gdrive.py
@@ -120,6 +120,25 @@ class Gdrive:
         item = results.get("files", [])
         return item[-1]["id"], item[-1]["name"]
 
+    def find_file_by_id(self, file_id):
+        """
+        Searching for file by id.
+        :str file_id: Id of the file which should be search.
+        :return: id, name of the founded file.
+        """
+        file_search = "mimeType != 'application/vnd.google-apps.folder'"
+        results = (
+            self.service.files()
+            .list(
+                fields="nextPageToken, files(id, name)",
+                orderBy="createdTime",
+                q=f"id = '{file_id}' and {file_search}",
+            )
+            .execute()
+        )
+        item = results.get("files", [])
+        return item[-1]["id"], item[-1]["name"]
+
     def get_files_in_folder(self, folder_id):
         """
         Searching for all files sorted by createdTime inside folder.

--- a/pygdrive/gdrive.py
+++ b/pygdrive/gdrive.py
@@ -180,7 +180,7 @@ class Gdrive:
         :str folder_id: : Id of the folder.
         :return: [{"id":"str", "name":"str"}]
         """
-        file_search = f"mimeType = {mimetype}"
+        file_search = f"mimeType = '{mimetype}'"
         results = (
             self.service.files()
             .list(

--- a/pygdrive/gdrive.py
+++ b/pygdrive/gdrive.py
@@ -3,8 +3,6 @@ from googleapiclient.discovery import build
 from os import path
 from googleapiclient.http import MediaFileUpload
 import json
-import os
-
 
 class Gdrive:
     """A class represent google drive."""
@@ -32,7 +30,7 @@ class Gdrive:
         :return: None
         """
         if self.credentials_env_var is not None:
-            service_account_info = json.loads(os.environ[self.credentials_env_var])
+            service_account_info = json.loads(self.credentials_env_var)
             credentials = service_account.Credentials.from_service_account_info(
                 service_account_info, scopes=self.scopes
             )

--- a/pygdrive/gdrive.py
+++ b/pygdrive/gdrive.py
@@ -173,6 +173,25 @@ class Gdrive:
         )
         item = results.get("files", [])
         return item
+        
+    def get_file_in_folder_by_type(self, folder_id, mimetype):
+        """
+        Searching for all folders sorted by createdTime inside folder.
+        :str folder_id: : Id of the folder.
+        :return: [{"id":"str", "name":"str"}]
+        """
+        file_search = f"mimeType = {mimetype}"
+        results = (
+            self.service.files()
+            .list(
+                fields="nextPageToken, files(id, name)",
+                orderBy="createdTime",
+                q=f"'{folder_id}' in parents and {file_search}",
+            )
+            .execute()
+        )
+        item = results.get("files", [])
+        return item
 
     def download_file(self, file_id, file_name, download_path=None):
         """

--- a/pygdrive/gdrive.py
+++ b/pygdrive/gdrive.py
@@ -127,16 +127,15 @@ class Gdrive:
         :return: id, name of the founded file.
         """
         file_search = "mimeType != 'application/vnd.google-apps.folder'"
-        results = (
+        result = (
             self.service.files()
-            .list(
-                fields="nextPageToken, files(id, name)",
-                orderBy="createdTime",
-                q=f"'{file_id}' and {file_search}",
+            .get(
+                fileId="{file_id}"
             )
             .execute()
         )
-        item = results.get("files", [])
+        print(result)
+        item = result.get("file", [])
         return item[-1]["id"], item[-1]["name"]
 
     def get_files_in_folder(self, folder_id):

--- a/pygdrive/gdrive.py
+++ b/pygdrive/gdrive.py
@@ -130,7 +130,7 @@ class Gdrive:
         result = (
             self.service.files()
             .get(
-                fileId="{file_id}"
+                fileId=file_id
             )
             .execute()
         )

--- a/pygdrive/gdrive.py
+++ b/pygdrive/gdrive.py
@@ -134,9 +134,7 @@ class Gdrive:
             )
             .execute()
         )
-        print(result)
-        item = result.get("file", [])
-        return item[-1]["id"], item[-1]["name"]
+        return result["id"], result["name"]
 
     def get_files_in_folder(self, folder_id):
         """

--- a/pygdrive/gdrive.py
+++ b/pygdrive/gdrive.py
@@ -132,7 +132,7 @@ class Gdrive:
             .list(
                 fields="nextPageToken, files(id, name)",
                 orderBy="createdTime",
-                q=f"id = '{file_id}' and {file_search}",
+                q=f"'{file_id}' and {file_search}",
             )
             .execute()
         )

--- a/pygdrive/gdrive.py
+++ b/pygdrive/gdrive.py
@@ -2,14 +2,17 @@ from google.oauth2 import service_account
 from googleapiclient.discovery import build
 from os import path
 from googleapiclient.http import MediaFileUpload
+import json
+import os
 
 
 class Gdrive:
     """A class represent google drive."""
 
-    def __init__(self, credentials_filepath, scopes, download_dir, upload_dir):
+    def __init__(self, credentials_filepath=None, credentials_env_var=None, scopes=None, download_dir=None, upload_dir=None):
         """
         :str credentials_filepath: The path to the service account json file.
+        :str credentials_env_var: Use an environment variable to provide service account credentials.
         :str scopes:  User-defined scopes to request during the
                 authorization grant.
         :str download_path: The path to the download folder.
@@ -17,6 +20,7 @@ class Gdrive:
         """
         self.service = None
         self.credentials_filepath = credentials_filepath
+        self.credentials_env_var = credentials_env_var
         self.scopes = scopes
         self.download_dir = download_dir
         self.upload_dir = upload_dir
@@ -24,12 +28,18 @@ class Gdrive:
 
     def connect(self):
         """
-        Creates a Credentials instance from a service account json file.
+        Creates a Credentials instance from a service account json file or an environment variable
         :return: None
         """
-        credentials = service_account.Credentials.from_service_account_file(
-            self.credentials_filepath, scopes=self.scopes
-        )
+        if self.credentials_env_var is not None:
+            service_account_info = json.loads(os.environ[self.credentials_env_var])
+            credentials = service_account.Credentials.from_service_account_info(
+                service_account_info, scopes=self.scopes
+            )
+        else:
+            credentials = service_account.Credentials.from_service_account_file(
+                self.credentials_filepath, scopes=self.scopes
+            )
         self.service = build("drive", "v3", credentials=credentials)
 
     def check_does_folder_exist(self, folder_name):

--- a/pygdrive/gdrive.py
+++ b/pygdrive/gdrive.py
@@ -146,7 +146,7 @@ class Gdrive:
         results = (
             self.service.files()
             .list(
-                fields="nextPageToken, files(id, name)",
+                fields="nextPageToken, files(id, name, mimeType)",
                 orderBy="createdTime",
                 q=f"'{folder_id}' in parents and {file_search}",
             )

--- a/pygdrive/gdrive.py
+++ b/pygdrive/gdrive.py
@@ -248,6 +248,19 @@ class Gdrive:
         )
         return file["id"]
 
+    def rename_file(self, file_id, file_name):
+        # First retrieve the file from the API.
+        file_metadata = self.service.files().get(fileId=file_id).execute()
+        # File's new metadata.
+        file_metadata['name'] = file_name
+
+        # Send the request to the API.
+        updated_file = self.service.files().update(
+            fileId=file_id,
+            body=file_metadata).execute()
+
+        return updated_file["id"]
+
     # def delete_file(self, file_id):
     #     """
     #     delete file or folder by id


### PR DESCRIPTION
Inspired from [pygsheet implementation](https://pygsheets.readthedocs.io/en/stable/authorization.html#environment-variables), add the possibility to initialize a Gdrive object with an **environment variable** (string format) instead of a credential file.

```
import os
from pygdrive import Gdrive
CREDENTIALS_JSON = os.environ["SERVICE_ACCOUNT_JSON"]
SCOPES = ['https://www.googleapis.com/auth/drive']
DOWNLOAD_DIR = 'download_dir/'
UPLOAD_DIR = 'upload_dir/'
gdrive_object = Gdrive(credentials_env_var=CREDENTIALS_JSON, 
                       scopes=SCOPES, 
                       download_dir=DOWNLOAD_DIR, 
                       upload_dir=UPLOAD_DIR) 
```